### PR TITLE
fun_with_strings: Use colon instead of period

### DIFF
--- a/satishtalim/fun_with_strings.html
+++ b/satishtalim/fun_with_strings.html
@@ -95,7 +95,7 @@
 
                 <p>
                   Here's a program <strong>p003rubystrings.rb</strong> that
-                  explores strings to some extent.
+                  explores strings to some extent:
                 </p>
 
                 <div class="column2">


### PR DESCRIPTION
This updates the end of the sentence to use a colon instead of a period,
to allude to example code, similarly to [L166](https://github.com/wbnns/rubylearning.github.io/blob/67573e28f85c31b25cf77d41390e279a24b45a79/satishtalim/fun_with_strings.html#L166).

Cc: @kotp 